### PR TITLE
Update readfile.py

### DIFF
--- a/mintpy/utils/readfile.py
+++ b/mintpy/utils/readfile.py
@@ -1687,7 +1687,7 @@ def read_snap_dim(fname):
     dim_dict['PLATFORM'] = sensor.standardize_sensor_name(dim_dict['PLATFORM'])
 
     # wavelength
-    dim_dict['WAVELENGTH'] = SPEED_OF_LIGHT / float(dim_dict['radar_frequency'])
+    dim_dict['WAVELENGTH'] = SPEED_OF_LIGHT / (float(dim_dict['radar_frequency'])* 1e6)
 
     # x/y_first/step_unit 
     transform = root.find("Geoposition/IMAGE_TO_MODEL_TRANSFORM").text.split(',')


### PR DESCRIPTION
Update to readfile.snap_dim to correctly calculate wavelength from radar frequency

The current calculation reads:
dim_dict['WAVELENGTH'] = SPEED_OF_LIGHT / float(dim_dict['radar_frequency'])

The updated calculation reads:
dim_dict['WAVELENGTH'] = SPEED_OF_LIGHT / (float(dim_dict['radar_frequency'])* 1e6) 

The update is needed for the correct calculation of the wavelength and therefore inversion of velocity. 

