### PR TITLE
Update ifgram_inversion.py

### DIFF
--- a/mintpy/ifgram_inversion.py
+++ b/mintpy/ifgram_inversion.py
@@ -755,7 +755,7 @@ def calc_weight_sqrt(stack_obj, box, weight_func='var', dropIfgram=True, chunk_s
         L = float(stack_obj.metadata['NCORRLOOKS'])
     else:
         # use the typical ratio of resolution vs pixel size of Sentinel-1 IW mode
-        L = int(stack_obj.metadata['ALOOKS']) * int(stack_obj.metadata['RLOOKS'])
+        L = int(float(stack_obj.metadata['ALOOKS'])) * int(float(stack_obj.metadata['RLOOKS']))
         L /= 1.94
     # make sure L >= 1
     L = max(np.rint(L).astype(int), 1)


### PR DESCRIPTION
The step-invert_network fails with:
File "/home/MintPy/mintpy/ifgram_inversion.py", line 758, in calc_weight_sqrt
    L = int(stack_obj.metadata['ALOOKS']) * int(stack_obj.metadata['RLOOKS'])
ValueError: invalid literal for int() with base 10: '1.0'

The fix proposes to change line 758 in ifgram_inversion.py
FROM
L = int(stack_obj.metadata['ALOOKS']) * int(stack_obj.metadata['RLOOKS'])
TO
L = int(float(stack_obj.metadata['ALOOKS'])) * int(float(stack_obj.metadata['RLOOKS']))

to fix the error
